### PR TITLE
Added replace parameters to Tracked annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.vgs</groupId>
     <artifactId>vgs-track</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/java/io/vgs/track/interceptor/EntityTrackingTransactionInterceptor.java
+++ b/src/main/java/io/vgs/track/interceptor/EntityTrackingTransactionInterceptor.java
@@ -195,10 +195,15 @@ public class EntityTrackingTransactionInterceptor extends EmptyInterceptor imple
         newValue = isEntity(newValue) ? retrieveIdFromEntity(newValue) : newValue;
 
         if (!Utils.equalsOrCompareEquals(oldValue, newValue)) {
-          addOrUpdateFieldData(entityData, new EntityTrackingFieldData(field.getName(), oldValue, newValue), newValue);
+          addOrUpdateFieldData(entityData, new EntityTrackingFieldData(field.getName(), getFieldValue(oldValue, field), getFieldValue(newValue, field)), newValue);
         }
       }
     }
+  }
+
+  private Object getFieldValue(Object value, Field field) {
+    Tracked tracked = field.getAnnotation(Tracked.class);
+    return tracked != null && tracked.replace() ? tracked.replaceWith() : value;
   }
 
   // it's implemented in onCollectionCreate and onCollectionUpdate

--- a/src/main/java/io/vgs/track/interceptor/EntityTrackingTransactionInterceptor.java
+++ b/src/main/java/io/vgs/track/interceptor/EntityTrackingTransactionInterceptor.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.persistence.Entity;
@@ -202,8 +203,10 @@ public class EntityTrackingTransactionInterceptor extends EmptyInterceptor imple
   }
 
   private Object getFieldValue(Object value, Field field) {
-    Tracked tracked = field.getAnnotation(Tracked.class);
-    return tracked != null && tracked.replace() ? tracked.replaceWith() : value;
+    return Optional.ofNullable(field.getAnnotation(Tracked.class))
+        .filter(Tracked::replace)
+        .map(t -> (Object) t.replaceWith())
+        .orElse(value);
   }
 
   // it's implemented in onCollectionCreate and onCollectionUpdate

--- a/src/main/java/io/vgs/track/meta/Tracked.java
+++ b/src/main/java/io/vgs/track/meta/Tracked.java
@@ -8,4 +8,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Tracked {
+  String DEFAULT_REPLACE = "HIDDEN";
+  boolean replace() default false;
+  String replaceWith() default DEFAULT_REPLACE;
 }

--- a/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
@@ -1,0 +1,89 @@
+package io.vgs.track.interceptor.transaction;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+public class ReplaceTrackedFieldTest extends BaseTest {
+
+  @Test
+  public void testReplaceValues() {
+    doInJpa(em -> {
+      Account account = new Account();
+      account.setName("Jonathan");
+      account.setVersion(42);
+      em.persist(account);
+    });
+
+    List<EntityTrackingData> trackingData = testEntityTrackingListener.getInserts();
+
+    Assert.assertThat(trackingData, Matchers.hasSize(1));
+
+    EntityTrackingFieldData fieldData1 = testEntityTrackingListener.getInsertedField("name");
+    Assert.assertThat(fieldData1.getNewValue(), CoreMatchers.equalTo("not for your eyes"));
+    Assert.assertThat(fieldData1.getOldValue(), CoreMatchers.equalTo("not for your eyes"));
+    EntityTrackingFieldData fieldData2 = testEntityTrackingListener.getInsertedField("version");
+    Assert.assertThat(fieldData2.getNewValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
+    Assert.assertThat(fieldData2.getOldValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
+  }
+
+  @Override
+  protected Class<?>[] entities() {
+    return new Class<?>[]{
+        Account.class
+    };
+  }
+
+  @Entity
+  @Trackable
+  public static class Account {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Tracked(replace = true, replaceWith = "not for your eyes")
+    private String name;
+
+    @Tracked(replace = true)
+    private Integer version;
+
+    public Integer getVersion() {
+      return version;
+    }
+
+    public void setVersion(Integer version) {
+      this.version = version;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public void setId(Long id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+
+  }
+}

--- a/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
@@ -21,10 +21,15 @@ public class ReplaceTrackedFieldTest extends BaseTest {
 
   @Test
   public void testReplaceValues() {
+    final String trackedFieldValue = "tracked field";
+    final String anotherTrackedFieldValue = "another tracked field";
+
     doInJpa(em -> {
       Account account = new Account();
       account.setName("Jonathan");
       account.setVersion(42);
+      account.setTracked(trackedFieldValue);
+      account.setAnotherTracked(anotherTrackedFieldValue);
       em.persist(account);
     });
 
@@ -38,6 +43,10 @@ public class ReplaceTrackedFieldTest extends BaseTest {
     EntityTrackingFieldData fieldData2 = testEntityTrackingListener.getInsertedField("version");
     Assert.assertThat(fieldData2.getNewValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
     Assert.assertThat(fieldData2.getOldValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
+    EntityTrackingFieldData fieldData3 = testEntityTrackingListener.getInsertedField("tracked");
+    Assert.assertThat(fieldData3.getNewValue(), CoreMatchers.equalTo(trackedFieldValue));
+    EntityTrackingFieldData fieldData4 = testEntityTrackingListener.getInsertedField("anotherTracked");
+    Assert.assertThat(fieldData4.getNewValue(), CoreMatchers.equalTo(anotherTrackedFieldValue));
   }
 
   @Override
@@ -59,6 +68,28 @@ public class ReplaceTrackedFieldTest extends BaseTest {
 
     @Tracked(replace = true)
     private Integer version;
+
+    @Tracked
+    private String tracked;
+
+    public String getTracked() {
+      return tracked;
+    }
+
+    public void setTracked(String tracked) {
+      this.tracked = tracked;
+    }
+
+    public String getAnotherTracked() {
+      return anotherTracked;
+    }
+
+    public void setAnotherTracked(String anotherTracked) {
+      this.anotherTracked = anotherTracked;
+    }
+
+    @Tracked(replace = false)
+    private String anotherTracked;
 
     public Integer getVersion() {
       return version;


### PR DESCRIPTION
Added two parameters to Tracked annotation: replace and replaceText
replace indicate that need to replace tracked filed value with text from replaceText