### PR TITLE
Revert to hibernate 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.vgs</groupId>
     <artifactId>vgs-track</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0</version>
     <name>Track</name>
     <description>Track</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.vgs</groupId>
@@ -11,30 +12,16 @@
 
     <properties>
         <java.version>1.8</java.version>
-
-        <!-- VGS -->
-        <logging-starter.version>0.10.2</logging-starter.version>
-
-        <!-- Misc -->
-        <hibernate.version>5.2.18.Final</hibernate.version>
-        <p6spy.version>3.0.0</p6spy.version>
-        <commons-collections.version>3.2.2</commons-collections.version>
+        <hibernate.version>4.3.11.Final</hibernate.version>
         <guava.version>24.1.1-jre</guava.version>
         <apache.commons.version>3.6</apache.commons.version>
         <h2.version>1.4.191</h2.version>
-        <lombok.version>1.18.12</lombok.version>
-        <lombok.encoding>UTF-8</lombok.encoding>
-
-        <!-- Testing -->
-        <junit.version>5.6.2</junit.version>
-        <hamcrest.version>2.2</hamcrest.version>
-
-        <!-- Plugins -->
-        <maven-compiler.version>3.8.0</maven-compiler.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <lombok-maven-plugin.version>1.18.12.0</lombok-maven-plugin.version>
+        <slf4j.version>1.7.7</slf4j.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <junit.version>4.12</junit.version>
+        <maven-compiler.version>3.1</maven-compiler.version>
+        <p6spy.version>3.0.0</p6spy.version>
+        <hamcrest.version>1.3</hamcrest.version>
     </properties>
 
     <distributionManagement>
@@ -43,7 +30,6 @@
             <name>AWS Release Repository</name>
             <url>s3://vault-dev-01-audits-01-artifact-19k6160zpr44j/software/release/</url>
         </repository>
-
         <snapshotRepository>
             <id>vault-http-snapshot</id>
             <name>AWS Snapshot Repository</name>
@@ -96,14 +82,7 @@
 
 
     <dependencies>
-        <!-- VGS -->
-        <dependency>
-            <groupId>com.verygood.security</groupId>
-            <artifactId>logging-core</artifactId>
-            <version>${logging-starter.version}</version>
-        </dependency>
-
-        <!-- Misc -->
+        <!-- Hibernate -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
@@ -116,19 +95,21 @@
             <version>${hibernate.version}</version>
         </dependency>
 
+        <!-- Logging -->
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
+        <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
 
+        <!-- Apache Common Collections -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -143,16 +124,9 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -168,6 +142,14 @@
             <artifactId>p6spy</artifactId>
             <version>${p6spy.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -180,51 +162,16 @@
             </extension>
         </extensions>
         <plugins>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler.version}</version>
                 <configuration>
-                    <target>${maven.compiler.target}</target>
-                    <source>${maven.compiler.source}</source>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                    <compilerArgs>
-                        <arg>-sourcepath</arg>
-                        <arg>
-                            ${project.basedir}/src/main/java${path.separator}${project.basedir}/target/generated-sources/annotations${path.separator}/
-                        </arg>
-                    </compilerArgs>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>${lombok-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>delombok</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirectory>src/main/java</sourceDirectory>
-                            <addOutputDirectory>false</addOutputDirectory>
-                            <outputDirectory>${project.build.directory}/delombok</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>com.amashchenko.maven.plugin</groupId>
                 <artifactId>gitflow-maven-plugin</artifactId>
@@ -251,6 +198,10 @@
                     </commitMessages>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.vgs</groupId>
     <artifactId>vgs-track</artifactId>
-    <version>2.0.0</version>
+    <version>1.0.3-SNAPSHOT</version>
     <name>Track</name>
     <description>Track</description>
 

--- a/src/test/java/io/vgs/track/BaseTest.java
+++ b/src/test/java/io/vgs/track/BaseTest.java
@@ -1,20 +1,7 @@
 package io.vgs.track;
 
 import com.p6spy.engine.spy.P6DataSource;
-import io.vgs.track.interceptor.EntityTrackingListenerAware;
-import io.vgs.track.interceptor.EntityTrackingTransactionInterceptor;
-import io.vgs.track.listener.TestEntityStateEntityTrackingListener;
-import io.vgs.track.sqltracker.QueryCountInfoHolder;
-import io.vgs.track.sqltracker.SqlCountTrackerDatasource;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Persistence;
-import javax.sql.DataSource;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -22,23 +9,39 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.Persistence;
+import javax.sql.DataSource;
+
+import io.vgs.track.interceptor.EntityTrackingListenerAware;
+import io.vgs.track.interceptor.EntityTrackingTransactionInterceptor;
+import io.vgs.track.listener.TestEntityStateEntityTrackingListener;
+import io.vgs.track.sqltracker.QueryCountInfoHolder;
+import io.vgs.track.sqltracker.SqlCountTrackerDatasource;
 
 public abstract class BaseTest {
-
   private SessionFactory sf;
   private EntityManagerFactory emf;
 
   protected TestEntityStateEntityTrackingListener testEntityTrackingListener = new TestEntityStateEntityTrackingListener();
 
-  @BeforeEach
+  @Before
   public void init() {
     sf = newSessionFactory();
     emf = newEntityManagerFactory();
   }
 
-  @AfterEach
+  @After
   public void destroy() {
     clearContext();
     sf.close();
@@ -124,9 +127,7 @@ public abstract class BaseTest {
       result = function.apply(entityManager);
       txn.commit();
     } catch (RuntimeException e) {
-      if (txn != null && txn.isActive()) {
-        txn.rollback();
-      }
+      if (txn != null && txn.isActive()) txn.rollback();
       throw e;
     } finally {
       if (entityManager != null) {
@@ -147,9 +148,7 @@ public abstract class BaseTest {
       function.accept(entityManager);
       txn.commit();
     } catch (RuntimeException e) {
-      if (txn != null && txn.isActive()) {
-        txn.rollback();
-      }
+      if (txn != null && txn.isActive()) txn.rollback();
       throw e;
     } finally {
       if (entityManager != null) {

--- a/src/test/java/io/vgs/track/interceptor/transaction/BothTrackedAndNotTrackedTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/BothTrackedAndNotTrackedTest.java
@@ -1,38 +1,35 @@
 package io.vgs.track.interceptor.transaction;
 
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
 import io.vgs.track.BaseTest;
 import io.vgs.track.exception.IllegalTrackingAnnotationsException;
 import io.vgs.track.meta.NotTracked;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class BothTrackedAndNotTrackedTest extends BaseTest {
 
-  @Test
+  @Test(expected = IllegalTrackingAnnotationsException.class)
   public void shouldThrowAnExceptionWhenFieldHasTrackedAndNotTrackedAnnotations() {
-    Assertions.assertThrows(IllegalTrackingAnnotationsException.class, () ->
-        doInJpa(em -> {
-          Fruit fruit = new Fruit();
-          fruit.setColor("green");
-          em.persist(fruit);
-        })
-    );
+    doInJpa(em -> {
+      Fruit fruit = new Fruit();
+      fruit.setColor("green");
+      em.persist(fruit);
+    });
   }
 
-  @Test
+  @Test(expected = IllegalTrackingAnnotationsException.class)
   public void shouldThrowAnExceptionWhenFieldHasTrackedAndNotTrackedAnnotationsAndClassHasTracked() {
-    Assertions.assertThrows(IllegalTrackingAnnotationsException.class, () ->
-        doInJpa(em -> {
-          Shop shop = new Shop();
-          shop.setName("macys");
-          em.persist(shop);
-        })
-    );
+    doInJpa(em -> {
+      Shop shop = new Shop();
+      shop.setName("macys");
+      em.persist(shop);
+    });
   }
 
   @Override
@@ -46,7 +43,6 @@ public class BothTrackedAndNotTrackedTest extends BaseTest {
   @Entity
   @Trackable
   private static class Fruit {
-
     @Id
     @GeneratedValue
     private Long id;
@@ -76,7 +72,6 @@ public class BothTrackedAndNotTrackedTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Shop {
-
     @Id
     @GeneratedValue
     private Long id;

--- a/src/test/java/io/vgs/track/interceptor/transaction/ElementCollectionListTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ElementCollectionListTest.java
@@ -1,26 +1,30 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-
 import com.google.common.collect.Lists;
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 public class ElementCollectionListTest extends BaseTest {
 
@@ -89,7 +93,6 @@ public class ElementCollectionListTest extends BaseTest {
   @Entity
   @Trackable
   public static class Client {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "client_seq")
     @SequenceGenerator(name = "client_seq", sequenceName = "client_seq")
@@ -119,6 +122,7 @@ public class ElementCollectionListTest extends BaseTest {
       nickNames.add(nickName);
     }
   }
+
 
   @Override
   protected Class<?>[] entities() {

--- a/src/test/java/io/vgs/track/interceptor/transaction/ElementCollectionSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ElementCollectionSetTest.java
@@ -1,30 +1,34 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-
 import com.google.common.collect.Sets;
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+
+import org.junit.Test;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class ElementCollectionSetTest extends BaseTest {
-
   @Test
   public void save() {
     Set<String> names = Sets.newHashSet("Flash", "Batman", "Thor");
@@ -91,7 +95,6 @@ public class ElementCollectionSetTest extends BaseTest {
   @Entity
   @Trackable
   public static class Client {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "client_seq")
     @SequenceGenerator(name = "client_seq", sequenceName = "client_seq")
@@ -118,6 +121,7 @@ public class ElementCollectionSetTest extends BaseTest {
     }
 
   }
+
 
   @Override
   protected Class<?>[] entities() {

--- a/src/test/java/io/vgs/track/interceptor/transaction/EmbeddedIdTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/EmbeddedIdTest.java
@@ -1,18 +1,21 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import java.io.Serializable;
-import java.util.List;
-import javax.persistence.Embeddable;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EmbeddedIdTest extends BaseTest {
 
@@ -36,7 +39,6 @@ public class EmbeddedIdTest extends BaseTest {
   @Tracked
   @Trackable
   private static class User {
-
     @EmbeddedId
     private UserId id;
 
@@ -64,7 +66,6 @@ public class EmbeddedIdTest extends BaseTest {
 
   @Embeddable
   private static class UserId implements Serializable {
-
     private String userName;
     private String departmentNr;
 
@@ -75,18 +76,13 @@ public class EmbeddedIdTest extends BaseTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       UserId userId = (UserId) o;
 
-      if (userName != null ? !userName.equals(userId.userName) : userId.userName != null) {
+      if (userName != null ? !userName.equals(userId.userName) : userId.userName != null)
         return false;
-      }
       return departmentNr != null ? departmentNr.equals(userId.departmentNr) : userId.departmentNr == null;
     }
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/IdClassTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/IdClassTest.java
@@ -1,14 +1,10 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.io.Serializable;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -17,7 +13,14 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class IdClassTest extends BaseTest {
 
@@ -103,7 +106,6 @@ public class IdClassTest extends BaseTest {
   @Trackable
   @Tracked
   private static class UserAccount {
-
     @Id
     @ManyToOne(optional = false)
     @JoinColumn(name = "account_id", referencedColumnName = "id", insertable = false, updatable = false)
@@ -132,24 +134,17 @@ public class IdClassTest extends BaseTest {
   }
 
   private static class UserAccountPK implements Serializable {
-
     private User user;
     private Account account;
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       UserAccountPK that = (UserAccountPK) o;
 
-      if (user != null ? !user.equals(that.user) : that.user != null) {
-        return false;
-      }
+      if (user != null ? !user.equals(that.user) : that.user != null) return false;
       return account != null ? account.equals(that.account) : that.account == null;
     }
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/ListenerIsNotProvidedTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ListenerIsNotProvidedTest.java
@@ -1,18 +1,21 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class ListenerIsNotProvidedTest extends BaseTest {
 
@@ -43,7 +46,6 @@ public class ListenerIsNotProvidedTest extends BaseTest {
   @Tracked
   @Trackable
   private static class Client {
-
     @Id
     @GeneratedValue
     private Long id;

--- a/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyBidirectionalListTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyBidirectionalListTest.java
@@ -1,20 +1,14 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -22,8 +16,18 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class ManyToManyBidirectionalListTest extends BaseTest {
@@ -50,12 +54,12 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
     assertThat(employees.getOldValue(), is(nullValue()));
     Collection<?> actualEmployeesNewValue = (Collection) employees.getNewValue();
     assertThat(actualEmployeesNewValue, hasSize(1));
-    assertThat(actualEmployeesNewValue, containsInAnyOrder(1L));
+    assertThat(actualEmployeesNewValue, containsInAnyOrder(50L));
 
     assertThat(projects.getOldValue(), is(nullValue()));
     Collection<?> actualProjectsNewValue = (Collection) employees.getNewValue();
     assertThat(actualProjectsNewValue, hasSize(1));
-    assertThat(actualProjectsNewValue, containsInAnyOrder(1L));
+    assertThat(actualProjectsNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -84,7 +88,7 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
     EntityTrackingFieldData employees = testEntityTrackingListener.getInsertedField("employees");
     assertThat(employees.getOldValue(), is(nullValue()));
     Collection<?> actualEmployeesNewValue = (Collection) employees.getNewValue();
-    assertThat(actualEmployeesNewValue, containsInAnyOrder(1L));
+    assertThat(actualEmployeesNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -112,7 +116,7 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
     EntityTrackingFieldData employees = testEntityTrackingListener.getUpdatedField("employees");
     assertThat(((Collection<?>) employees.getOldValue()), hasSize(0));
     assertThat(((Collection<?>) employees.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) employees.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) employees.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -150,13 +154,13 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(2));
-    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(1L, 2L));
+    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(50L, 51L));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(2L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(51L));
 
     EntityTrackingFieldData employees = testEntityTrackingListener.getUpdatedField("employees");
     assertThat(((Collection<?>) employees.getOldValue()), hasSize(1));
-    assertThat(((Collection<?>) employees.getOldValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) employees.getOldValue()), containsInAnyOrder(50L));
     assertThat(((Collection<?>) employees.getNewValue()), hasSize(0));
   }
 
@@ -172,7 +176,6 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Employee {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "employee_seq")
     @SequenceGenerator(name = "employee_seq", sequenceName = "employee_seq")
@@ -209,7 +212,6 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Project {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "project_seq")
     @SequenceGenerator(name = "project_seq", sequenceName = "project_seq")
@@ -262,12 +264,8 @@ public class ManyToManyBidirectionalListTest extends BaseTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       Project project = (Project) o;
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyBidirectionalSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyBidirectionalSetTest.java
@@ -1,20 +1,14 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -24,12 +18,21 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class ManyToManyBidirectionalSetTest extends BaseTest {
-
   @Test
   public void simpleSynchronization() {
     doInJpa(em -> {
@@ -52,12 +55,12 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
     assertThat(employees.getOldValue(), is(nullValue()));
     Collection<?> actualEmployeesNewValue = (Collection) employees.getNewValue();
     assertThat(actualEmployeesNewValue, hasSize(1));
-    assertThat(actualEmployeesNewValue, containsInAnyOrder(1L));
+    assertThat(actualEmployeesNewValue, containsInAnyOrder(50L));
 
     assertThat(projects.getOldValue(), is(nullValue()));
     Collection<?> actualProjectsNewValue = (Collection) employees.getNewValue();
     assertThat(actualProjectsNewValue, hasSize(1));
-    assertThat(actualProjectsNewValue, containsInAnyOrder(1L));
+    assertThat(actualProjectsNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -86,7 +89,7 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
     EntityTrackingFieldData employees = testEntityTrackingListener.getInsertedField("employees");
     assertThat(employees.getOldValue(), is(nullValue()));
     Collection<?> actualEmployeesNewValue = (Collection) employees.getNewValue();
-    assertThat(actualEmployeesNewValue, containsInAnyOrder(1L));
+    assertThat(actualEmployeesNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -114,12 +117,12 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()).isEmpty(), is(true));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData employees = testEntityTrackingListener.getUpdatedField("employees");
     assertThat(((Collection<?>) employees.getOldValue()).isEmpty(), is(true));
     assertThat(((Collection<?>) employees.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) employees.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) employees.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -157,13 +160,13 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(2));
-    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(1L, 2L));
+    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(50L, 51L));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(2L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(51L));
 
     EntityTrackingFieldData employees = testEntityTrackingListener.getUpdatedField("employees");
     assertThat(((Collection<?>) employees.getOldValue()), hasSize(1));
-    assertThat(((Collection<?>) employees.getOldValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) employees.getOldValue()), containsInAnyOrder(50L));
     assertThat(((Collection<?>) employees.getNewValue()), hasSize(0));
   }
 
@@ -179,7 +182,6 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Employee {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "employee_seq")
     @SequenceGenerator(name = "employee_seq", sequenceName = "employee_seq")
@@ -216,7 +218,6 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Project {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "project_seq")
     @SequenceGenerator(name = "project_seq", sequenceName = "project_seq")
@@ -269,12 +270,8 @@ public class ManyToManyBidirectionalSetTest extends BaseTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       Project project = (Project) o;
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyUnidirectionalListTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyUnidirectionalListTest.java
@@ -1,31 +1,33 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class ManyToManyUnidirectionalListTest extends BaseTest {
-
   @Test
   public void simpleSynchronization() {
     doInJpa(em -> {
@@ -44,7 +46,7 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
     assertThat(projects.getOldValue(), is(nullValue()));
     Collection<?> actualProjectsNewValue = (Collection) projects.getNewValue();
     assertThat(actualProjectsNewValue, hasSize(1));
-    assertThat(actualProjectsNewValue, containsInAnyOrder(1L));
+    assertThat(actualProjectsNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -74,10 +76,10 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
     Collection<?> actualNewValue = (Collection) projects.getNewValue();
 
     assertThat(actualOldValue, hasSize(1));
-    assertThat(actualOldValue, containsInAnyOrder(1L));
+    assertThat(actualOldValue, containsInAnyOrder(50L));
 
     assertThat(actualNewValue, hasSize(2));
-    assertThat(actualNewValue, containsInAnyOrder(1L, 2L));
+    assertThat(actualNewValue, containsInAnyOrder(50L, 51L));
   }
 
   @Test
@@ -104,7 +106,7 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(0));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -138,9 +140,9 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(2));
-    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(1L, 2L));
+    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(50L, 51L));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(2L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(51L));
   }
 
   @Override
@@ -155,7 +157,6 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Employee {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "employee_seq")
     @SequenceGenerator(name = "employee_seq", sequenceName = "employee_seq")
@@ -192,7 +193,6 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Project {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "project_seq")
     @SequenceGenerator(name = "project_seq", sequenceName = "project_seq")
@@ -225,12 +225,8 @@ public class ManyToManyUnidirectionalListTest extends BaseTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       Project project = (Project) o;
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyUnidirectionalSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ManyToManyUnidirectionalSetTest.java
@@ -1,28 +1,32 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class ManyToManyUnidirectionalSetTest extends BaseTest {
@@ -45,7 +49,7 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
     assertThat(projects.getOldValue(), is(nullValue()));
     Collection<?> actualProjectsNewValue = (Collection) projects.getNewValue();
     assertThat(actualProjectsNewValue, hasSize(1));
-    assertThat(actualProjectsNewValue, containsInAnyOrder(1L));
+    assertThat(actualProjectsNewValue, containsInAnyOrder(50L));
   }
 
   @Test
@@ -77,10 +81,10 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
     Collection<?> actualNewValue = (Collection) projects.getNewValue();
 
     assertThat(actualOldValue, hasSize(1));
-    assertThat(actualOldValue, containsInAnyOrder(1L));
+    assertThat(actualOldValue, containsInAnyOrder(50L));
 
     assertThat(actualNewValue, hasSize(2));
-    assertThat(actualNewValue, containsInAnyOrder(1L, 2L));
+    assertThat(actualNewValue, containsInAnyOrder(50L, 51L));
   }
 
   @Test
@@ -107,7 +111,7 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(0));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -141,9 +145,9 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData projects = testEntityTrackingListener.getUpdatedField("projects");
     assertThat(((Collection<?>) projects.getOldValue()), hasSize(2));
-    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(1L, 2L));
+    assertThat(((Collection<?>) projects.getOldValue()), containsInAnyOrder(50L, 51L));
     assertThat(((Collection<?>) projects.getNewValue()), hasSize(1));
-    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(2L));
+    assertThat(((Collection<?>) projects.getNewValue()), containsInAnyOrder(51L));
   }
 
   @Override
@@ -158,7 +162,6 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Employee {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "employee_seq")
     @SequenceGenerator(name = "employee_seq", sequenceName = "employee_seq")
@@ -195,7 +198,6 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
   @Tracked
   @Trackable
   public static class Project {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "project_seq")
     @SequenceGenerator(name = "project_seq", sequenceName = "project_seq")
@@ -228,12 +230,8 @@ public class ManyToManyUnidirectionalSetTest extends BaseTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
       Project project = (Project) o;
 

--- a/src/test/java/io/vgs/track/interceptor/transaction/MapEntityMappingTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/MapEntityMappingTest.java
@@ -1,15 +1,10 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -20,7 +15,15 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MapKey;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MapEntityMappingTest extends BaseTest {
 
@@ -53,7 +56,6 @@ public class MapEntityMappingTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -94,7 +96,6 @@ public class MapEntityMappingTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/MapPrimitiveMappingTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/MapPrimitiveMappingTest.java
@@ -1,24 +1,28 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import com.google.common.collect.ImmutableMap;
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MapPrimitiveMappingTest extends BaseTest {
 
@@ -42,7 +46,6 @@ public class MapPrimitiveMappingTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Employee {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "employee_seq")
     @SequenceGenerator(name = "employee_seq", sequenceName = "employee_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/NotTrackableTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/NotTrackableTest.java
@@ -1,16 +1,20 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.meta.Tracked;
-import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class NotTrackableTest extends BaseTest {
 
@@ -34,7 +38,6 @@ public class NotTrackableTest extends BaseTest {
 
   @Entity
   private static class Client {
-
     @Id
     @GeneratedValue
     private Long id;

--- a/src/test/java/io/vgs/track/interceptor/transaction/NotTrackedFieldTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/NotTrackedFieldTest.java
@@ -1,22 +1,25 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.meta.NotTracked;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import java.util.Date;
-import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class NotTrackedFieldTest extends BaseTest {
-
   @Test
   public void shouldNotTrackEntityFieldIfItDoesNotHaveTrackedAnnotation() {
     doInJpa(em -> {
@@ -60,7 +63,6 @@ public class NotTrackedFieldTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Client {
-
     @Id
     @GeneratedValue
     private Long id;
@@ -99,7 +101,6 @@ public class NotTrackedFieldTest extends BaseTest {
   @Entity
   @Trackable
   private static class Account {
-
     @Id
     @GeneratedValue
     private Long id;
@@ -127,7 +128,6 @@ public class NotTrackedFieldTest extends BaseTest {
   @Trackable
   @Tracked
   private static class Passport {
-
     @Id
     @GeneratedValue
     private Long id;

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalListCascadeTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalListCascadeTest.java
@@ -1,19 +1,13 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -23,9 +17,18 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class OneToManyBidirectionalListCascadeTest extends BaseTest {
@@ -46,18 +49,17 @@ public class OneToManyBidirectionalListCascadeTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData address = testEntityTrackingListener.getInsertedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -88,7 +90,6 @@ public class OneToManyBidirectionalListCascadeTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalListTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalListTest.java
@@ -1,19 +1,11 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -23,7 +15,18 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class OneToManyBidirectionalListTest extends BaseTest {
@@ -47,11 +50,11 @@ public class OneToManyBidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData address = testEntityTrackingListener.getInsertedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Test
@@ -78,18 +81,17 @@ public class OneToManyBidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData address = testEntityTrackingListener.getUpdatedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -120,7 +122,6 @@ public class OneToManyBidirectionalListTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToManyBidirectionalSetTest.java
@@ -1,20 +1,12 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -24,11 +16,21 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class OneToManyBidirectionalSetTest extends BaseTest {
-
   @Test
   public void insertWithRightOrder() {
     doInJpa(em -> {
@@ -48,11 +50,11 @@ public class OneToManyBidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData address = testEntityTrackingListener.getInsertedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Test
@@ -79,18 +81,17 @@ public class OneToManyBidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
 
     EntityTrackingFieldData address = testEntityTrackingListener.getUpdatedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -121,7 +122,6 @@ public class OneToManyBidirectionalSetTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToManyUnidirectionalListTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToManyUnidirectionalListTest.java
@@ -1,30 +1,32 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class OneToManyUnidirectionalListTest extends BaseTest {
-
   @Test
   public void insertWithRightOrder() {
     doInJpa(em -> {
@@ -43,7 +45,7 @@ public class OneToManyUnidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -66,14 +68,13 @@ public class OneToManyUnidirectionalListTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -93,7 +94,6 @@ public class OneToManyUnidirectionalListTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToManyUnidirectionalSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToManyUnidirectionalSetTest.java
@@ -1,27 +1,31 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 @SuppressWarnings("Duplicates")
 public class OneToManyUnidirectionalSetTest extends BaseTest {
@@ -44,7 +48,7 @@ public class OneToManyUnidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Test
@@ -67,14 +71,13 @@ public class OneToManyUnidirectionalSetTest extends BaseTest {
 
     EntityTrackingFieldData cars = testEntityTrackingListener.getInsertedField("cars");
     assertThat(cars.getOldValue(), is(nullValue()));
-    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(1L));
+    assertThat(((Collection<?>) cars.getNewValue()), containsInAnyOrder(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")
@@ -94,7 +97,6 @@ public class OneToManyUnidirectionalSetTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToOneBidirectionalTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToOneBidirectionalTest.java
@@ -1,16 +1,9 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -19,7 +12,17 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 @SuppressWarnings("Duplicates")
 public class OneToOneBidirectionalTest extends BaseTest {
@@ -41,7 +44,7 @@ public class OneToOneBidirectionalTest extends BaseTest {
     assertThat(inserts, hasSize(1));
     EntityTrackingFieldData client = testEntityTrackingListener.getInsertedField("client");
     assertThat(client.getOldValue(), is(nullValue()));
-    assertThat(client.getNewValue(), is(1L));
+    assertThat(client.getNewValue(), is(50L));
   }
 
   @Test
@@ -63,10 +66,10 @@ public class OneToOneBidirectionalTest extends BaseTest {
     assertThat(updates, hasSize(1));
     EntityTrackingFieldData address = testEntityTrackingListener.getInsertedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
     EntityTrackingFieldData client = testEntityTrackingListener.getUpdatedField("client");
     assertThat(client.getOldValue(), is(nullValue()));
-    assertThat(client.getNewValue(), is(1L));
+    assertThat(client.getNewValue(), is(50L));
   }
 
   @Test
@@ -102,25 +105,24 @@ public class OneToOneBidirectionalTest extends BaseTest {
 
     List<EntityTrackingData> updates = testEntityTrackingListener.getUpdates();
     assertThat(updates, hasSize(2));
-    EntityTrackingData firstAddress = testEntityTrackingListener.getUpdatedEntity(1L);
-    EntityTrackingData secondAddress = testEntityTrackingListener.getUpdatedEntity(2L);
+    EntityTrackingData firstAddress = testEntityTrackingListener.getUpdatedEntity(50L);
+    EntityTrackingData secondAddress = testEntityTrackingListener.getUpdatedEntity(51L);
     assertThat(firstAddress.getEntityTrackingFields(), hasSize(1));
     assertThat(secondAddress.getEntityTrackingFields(), hasSize(1));
 
     EntityTrackingFieldData clientOfFirstAddress = firstAddress.getEntityTrackingFields().get(0);
-    assertThat(clientOfFirstAddress.getOldValue(), is(1L));
+    assertThat(clientOfFirstAddress.getOldValue(), is(50L));
     assertThat(clientOfFirstAddress.getNewValue(), is(nullValue()));
 
     EntityTrackingFieldData clientOfSecondAddress = secondAddress.getEntityTrackingFields().get(0);
     assertThat(clientOfSecondAddress.getOldValue(), is(nullValue()));
-    assertThat(clientOfSecondAddress.getNewValue(), is(1L));
+    assertThat(clientOfSecondAddress.getNewValue(), is(50L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Client {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "client_seq")
     @SequenceGenerator(name = "client_seq", sequenceName = "client_seq")
@@ -163,7 +165,6 @@ public class OneToOneBidirectionalTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Passport {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")
@@ -193,7 +194,6 @@ public class OneToOneBidirectionalTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/OneToOneUnidirectionalTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/OneToOneUnidirectionalTest.java
@@ -1,16 +1,9 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingData;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -19,7 +12,17 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingData;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 @SuppressWarnings("Duplicates")
 public class OneToOneUnidirectionalTest extends BaseTest {
@@ -40,7 +43,7 @@ public class OneToOneUnidirectionalTest extends BaseTest {
     assertThat(inserts, hasSize(1));
     EntityTrackingFieldData client = testEntityTrackingListener.getInsertedField("address");
     assertThat(client.getOldValue(), is(nullValue()));
-    assertThat(client.getNewValue(), is(1L));
+    assertThat(client.getNewValue(), is(50L));
   }
 
   @Test
@@ -59,7 +62,7 @@ public class OneToOneUnidirectionalTest extends BaseTest {
     assertThat(updates, hasSize(1));
     EntityTrackingFieldData address = testEntityTrackingListener.getUpdatedField("address");
     assertThat(address.getOldValue(), is(nullValue()));
-    assertThat(address.getNewValue(), is(1L));
+    assertThat(address.getNewValue(), is(50L));
   }
 
   @Test
@@ -91,15 +94,14 @@ public class OneToOneUnidirectionalTest extends BaseTest {
     List<EntityTrackingData> updates = testEntityTrackingListener.getUpdates();
     assertThat(updates, hasSize(1));
     EntityTrackingFieldData address = testEntityTrackingListener.getUpdatedField("address");
-    assertThat(address.getOldValue(), is(1L));
-    assertThat(address.getNewValue(), is(2L));
+    assertThat(address.getOldValue(), is(50L));
+    assertThat(address.getNewValue(), is(51L));
   }
 
   @Entity
   @Trackable
   @Tracked
   public static class Client {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "client_seq")
     @SequenceGenerator(name = "client_seq", sequenceName = "client_seq")
@@ -142,7 +144,6 @@ public class OneToOneUnidirectionalTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Passport {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")
@@ -172,7 +173,6 @@ public class OneToOneUnidirectionalTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/PersistentBagTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/PersistentBagTest.java
@@ -1,15 +1,12 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.hibernate.Hibernate;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -19,8 +16,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.hibernate.Hibernate;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @SuppressWarnings("Duplicates")
 public class PersistentBagTest extends BaseTest {
@@ -103,7 +106,6 @@ public class PersistentBagTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")
@@ -133,7 +135,6 @@ public class PersistentBagTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/PersistentSetTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/PersistentSetTest.java
@@ -1,15 +1,11 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
-import io.vgs.track.BaseTest;
-import io.vgs.track.data.EntityTrackingFieldData;
-import io.vgs.track.meta.Trackable;
-import io.vgs.track.meta.Tracked;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -19,7 +15,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import io.vgs.track.BaseTest;
+import io.vgs.track.data.EntityTrackingFieldData;
+import io.vgs.track.meta.Trackable;
+import io.vgs.track.meta.Tracked;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @SuppressWarnings("Duplicates")
 public class PersistentSetTest extends BaseTest {
@@ -69,7 +72,6 @@ public class PersistentSetTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Address {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "address_seq")
     @SequenceGenerator(name = "address_seq", sequenceName = "address_seq")
@@ -99,7 +101,6 @@ public class PersistentSetTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Car {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_seq")
     @SequenceGenerator(name = "car_seq", sequenceName = "car_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/PrimitiveFieldsTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/PrimitiveFieldsTest.java
@@ -1,23 +1,26 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.data.EntityTrackingFieldData;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import java.io.Serializable;
-import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
 
 @SuppressWarnings("Duplicates")
 public class PrimitiveFieldsTest extends BaseTest {
@@ -190,7 +193,6 @@ public class PrimitiveFieldsTest extends BaseTest {
   @Trackable
   @Tracked
   public static class Account {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "account_seq")
     @SequenceGenerator(name = "account_seq", sequenceName = "account_seq")
@@ -219,7 +221,6 @@ public class PrimitiveFieldsTest extends BaseTest {
   @Trackable
   @Tracked
   public static class SimpleEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "account_seq")
     @SequenceGenerator(name = "account_seq", sequenceName = "account_seq")

--- a/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
+++ b/src/test/java/io/vgs/track/interceptor/transaction/ReplaceTrackedFieldTest.java
@@ -1,19 +1,21 @@
 package io.vgs.track.interceptor.transaction;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
 import io.vgs.track.BaseTest;
 import io.vgs.track.data.EntityTrackingData;
 import io.vgs.track.data.EntityTrackingFieldData;
 import io.vgs.track.meta.Trackable;
 import io.vgs.track.meta.Tracked;
-import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 
 public class ReplaceTrackedFieldTest extends BaseTest {
 
@@ -33,18 +35,18 @@ public class ReplaceTrackedFieldTest extends BaseTest {
 
     List<EntityTrackingData> trackingData = testEntityTrackingListener.getInserts();
 
-    assertThat(trackingData, Matchers.hasSize(1));
+    Assert.assertThat(trackingData, Matchers.hasSize(1));
 
     EntityTrackingFieldData fieldData1 = testEntityTrackingListener.getInsertedField("name");
-    assertThat(fieldData1.getNewValue(), CoreMatchers.equalTo("not for your eyes"));
-    assertThat(fieldData1.getOldValue(), CoreMatchers.equalTo("not for your eyes"));
+    Assert.assertThat(fieldData1.getNewValue(), CoreMatchers.equalTo("not for your eyes"));
+    Assert.assertThat(fieldData1.getOldValue(), CoreMatchers.equalTo("not for your eyes"));
     EntityTrackingFieldData fieldData2 = testEntityTrackingListener.getInsertedField("version");
-    assertThat(fieldData2.getNewValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
-    assertThat(fieldData2.getOldValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
+    Assert.assertThat(fieldData2.getNewValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
+    Assert.assertThat(fieldData2.getOldValue(), CoreMatchers.equalTo(Tracked.DEFAULT_REPLACE));
     EntityTrackingFieldData fieldData3 = testEntityTrackingListener.getInsertedField("tracked");
-    assertThat(fieldData3.getNewValue(), CoreMatchers.equalTo(trackedFieldValue));
+    Assert.assertThat(fieldData3.getNewValue(), CoreMatchers.equalTo(trackedFieldValue));
     EntityTrackingFieldData fieldData4 = testEntityTrackingListener.getInsertedField("anotherTracked");
-    assertThat(fieldData4.getNewValue(), CoreMatchers.equalTo(anotherTrackedFieldValue));
+    Assert.assertThat(fieldData4.getNewValue(), CoreMatchers.equalTo(anotherTrackedFieldValue));
   }
 
   @Override
@@ -57,7 +59,6 @@ public class ReplaceTrackedFieldTest extends BaseTest {
   @Entity
   @Trackable
   public static class Account {
-
     @Id
     @GeneratedValue
     private Long id;


### PR DESCRIPTION
Turned out our **VAULT** project depends on` SNAPSHOT` version of `track` 🤦 


## Fixes #XXXX

<!-- section -->
## Description of changes in release / Impact of release:
(insert text here)

<!-- section -->
## Value being added to the product or risk being removed by this release
(insert text here)

<!-- section --> 
## Who is accountable for this change except yourself?
(insert text here)

<!-- section -->
## Risks of this release

<!-- section -->
### Is this a breaking change?
  - [ ] Yes
  - [ ] No

<!-- section -->
### If you answered Yes then describe why is it so
(insert text here)

<!-- section -->
### Is there a way to disable the change?
  - [ ] Deploy the previous release
  - [ ] Use a feature flag
  - [ ] Make a FE change that hides a faulty feature
  - [ ] No

<!-- section -->
#### Additional details go here
(insert text here)

<!-- section -->
### If you answered No then please explain why it is acceptable?
(insert text here)
